### PR TITLE
게시판 서비스 기능 구현 - LOST42-7

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,7 +1,14 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.17'
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id 'com.ewerk.gradle.plugins.querydsl' version '1.0.10'
 }
 
 group = 'Lost42'
@@ -47,10 +54,33 @@ dependencies {
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // queryDsl
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+    implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+sourceSets {
+    main.java.srcDir querydslDir
+}
+compileQuerydsl{
+    options.annotationProcessorPath = configurations.querydsl
+}
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+    querydsl.extendsFrom compileClasspath
 }

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -58,6 +58,9 @@ dependencies {
     implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
     implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
 
+    // aws S3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/backend/src/main/java/lost42/backend/common/auth/dto/CustomUserDetails.java
+++ b/backend/src/main/java/lost42/backend/common/auth/dto/CustomUserDetails.java
@@ -40,7 +40,7 @@ public class CustomUserDetails implements UserDetails {
         this.memberId = member.getMemberId();
         this.oauthProvider = member.getOauthProvider();
         this.oauthId = member.getOauthId();
-        this.authorities = Arrays.stream(new String[]{member.getRole().getKey()})
+        this.authorities = Arrays.stream(new String[]{member.getRole().getRole()})
                 .map(role -> new SimpleGrantedAuthority(role))
                 .collect(Collectors.toList());
     }

--- a/backend/src/main/java/lost42/backend/common/auth/dto/OauthAttribute.java
+++ b/backend/src/main/java/lost42/backend/common/auth/dto/OauthAttribute.java
@@ -2,7 +2,7 @@ package lost42.backend.common.auth.dto;
 
 import lombok.Builder;
 import lombok.Getter;
-import lost42.backend.common.auth.MemberRole;
+import lost42.backend.domain.member.entity.MemberRole;
 import lost42.backend.domain.member.entity.Member;
 
 import java.util.Map;

--- a/backend/src/main/java/lost42/backend/common/auth/service/CustomOauth2UserService.java
+++ b/backend/src/main/java/lost42/backend/common/auth/service/CustomOauth2UserService.java
@@ -38,7 +38,7 @@ public class CustomOauth2UserService implements OAuth2UserService<OAuth2UserRequ
         attributes.updateMemberId(member.getMemberId());
 
         return new CustomOAuth2User(
-                Collections.singleton(new SimpleGrantedAuthority(member.getRole().getKey())),
+                Collections.singleton(new SimpleGrantedAuthority(member.getRole().getRole())),
                 attributes.getAttributes(),
                 attributes.getNameAttributeKey(),
                 attributes.getMemberId(),

--- a/backend/src/main/java/lost42/backend/common/handler/ProjectErrorExceptionHandler.java
+++ b/backend/src/main/java/lost42/backend/common/handler/ProjectErrorExceptionHandler.java
@@ -1,9 +1,9 @@
 package lost42.backend.common.handler;
 
 import lombok.extern.slf4j.Slf4j;
-import lost42.backend.common.Response.ErrorResponse;
+import lost42.backend.common.response.ErrorResponse;
 import lost42.backend.common.exception.GlobalErrorException;
-import lost42.backend.common.auth.exception.AuthErrorException;
+import lost42.backend.domain.board.exception.BoardErrorException;
 import lost42.backend.domain.member.exception.MemberErrorException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -29,6 +29,13 @@ public class ProjectErrorExceptionHandler {
     @ExceptionHandler(MemberErrorException.class)
     protected ResponseEntity<ErrorResponse> handleMemberErrorException(MemberErrorException e) {
         log.warn("handleMemberErrorException : {}", e.getMessage());
+        final ErrorResponse errorResponse = ErrorResponse.of(e.getMessage());
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(errorResponse);
+    }
+
+    @ExceptionHandler(BoardErrorException.class)
+    protected ResponseEntity<ErrorResponse> handleBoardErrorException(BoardErrorException e) {
+        log.warn("handleBoardErrorException : {}", e.getMessage());
         final ErrorResponse errorResponse = ErrorResponse.of(e.getMessage());
         return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(errorResponse);
     }

--- a/backend/src/main/java/lost42/backend/common/handler/ProjectErrorExceptionHandler.java
+++ b/backend/src/main/java/lost42/backend/common/handler/ProjectErrorExceptionHandler.java
@@ -1,6 +1,8 @@
 package lost42.backend.common.handler;
 
+import io.jsonwebtoken.security.SignatureException;
 import lombok.extern.slf4j.Slf4j;
+import lost42.backend.common.code.ErrorCode;
 import lost42.backend.common.response.ErrorResponse;
 import lost42.backend.common.exception.GlobalErrorException;
 import lost42.backend.domain.board.exception.BoardErrorException;
@@ -38,5 +40,12 @@ public class ProjectErrorExceptionHandler {
         log.warn("handleBoardErrorException : {}", e.getMessage());
         final ErrorResponse errorResponse = ErrorResponse.of(e.getMessage());
         return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(errorResponse);
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.warn("handleException : {}", e.getMessage());
+        final ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR.getMessage());
+        return ResponseEntity.status(e.hashCode()).body(errorResponse);
     }
 }

--- a/backend/src/main/java/lost42/backend/common/jwt/JwtTokenValidation.java
+++ b/backend/src/main/java/lost42/backend/common/jwt/JwtTokenValidation.java
@@ -1,0 +1,12 @@
+package lost42.backend.common.jwt;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JwtTokenValidation {
+    boolean enable() default true;
+}

--- a/backend/src/main/java/lost42/backend/common/jwt/filter/CustomJwtFilter.java
+++ b/backend/src/main/java/lost42/backend/common/jwt/filter/CustomJwtFilter.java
@@ -17,6 +17,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;
@@ -58,7 +59,7 @@ public class CustomJwtFilter extends OncePerRequestFilter {
 
         String accessToken = jwtTokenUtil.resolveAccessToken(request);
         String refreshToken = jwtTokenUtil.resolveRefreshToken(request);
-        if (accessToken == null && refreshToken == null) {
+        if (!StringUtils.hasText(accessToken) || !StringUtils.hasText(refreshToken)) {
             filterChain.doFilter(request,response);
             return;
         }

--- a/backend/src/main/java/lost42/backend/common/jwt/filter/CustomJwtFilter.java
+++ b/backend/src/main/java/lost42/backend/common/jwt/filter/CustomJwtFilter.java
@@ -3,7 +3,7 @@ package lost42.backend.common.jwt.filter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import lost42.backend.common.Response.ErrorResponse;
+import lost42.backend.common.response.ErrorResponse;
 import lost42.backend.common.jwt.JwtTokenUtil;
 import lost42.backend.common.jwt.dto.JwtTokenInfo;
 import lost42.backend.common.jwt.provider.TokenProvider;

--- a/backend/src/main/java/lost42/backend/common/jwt/filter/CustomJwtFilter.java
+++ b/backend/src/main/java/lost42/backend/common/jwt/filter/CustomJwtFilter.java
@@ -43,7 +43,8 @@ public class CustomJwtFilter extends OncePerRequestFilter {
             "/swagger", "/swagger-ui/**", "/v3/api-docs/**",
             "/api/v1/members/signin", "/oauth2/**", "/api/v1/members/signup",
             "/api/v1/jwt/test",
-            "/api/v1/members/find-email", "/api/v1/members/find-password", "/api/v1/members/auth"
+            "/api/v1/members/find-email", "/api/v1/members/find-password", "/api/v1/members/auth",
+            "/api/v1/boards/get"
     );
 
 

--- a/backend/src/main/java/lost42/backend/common/jwt/interceptor/JwtTokenValidationInterceptor.java
+++ b/backend/src/main/java/lost42/backend/common/jwt/interceptor/JwtTokenValidationInterceptor.java
@@ -1,0 +1,76 @@
+package lost42.backend.common.jwt.interceptor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lost42.backend.common.auth.dto.CustomUserDetails;
+import lost42.backend.common.auth.exception.AuthErrorCode;
+import lost42.backend.common.auth.service.CustomUserDetailsService;
+import lost42.backend.common.jwt.JwtTokenUtil;
+import lost42.backend.common.jwt.JwtTokenValidation;
+import lost42.backend.common.response.ErrorResponse;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+public class JwtTokenValidationInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if (handler instanceof HandlerMethod) {
+            HandlerMethod handlerMethod = (HandlerMethod) handler;
+
+            JwtTokenValidation annotation = AnnotationUtils.findAnnotation(handlerMethod.getMethod(), JwtTokenValidation.class);
+            if (annotation != null && annotation.enable()) {
+                log.warn("JwtInterceptor: {}", request.getRequestURI());
+                String accessToken = resolveAccessToken(request);
+                String refreshToken = resolveRefreshToken(request);
+
+                if (accessToken == null) {
+                    handleAuthErrorException(response, AuthErrorCode.EMPTY_ACCESS_TOKEN);
+                    return false;
+                } else if (refreshToken == null) {
+                    handleAuthErrorException(response, AuthErrorCode.EMPTY_REFRESH_TOKEN);
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    public String resolveAccessToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    public String resolveRefreshToken(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("refreshToken".equals(cookie.getName()))
+                    return cookie.getValue();
+            }
+        }
+        return null;
+    }
+
+    private void handleAuthErrorException(HttpServletResponse response, AuthErrorCode errorCode) throws IOException {
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        String json = new ObjectMapper().writeValueAsString(ErrorResponse.of(errorCode.getMessage()));
+        response.getWriter().write(json);
+    }
+}
+

--- a/backend/src/main/java/lost42/backend/common/redis/refreshtoken/RefreshTokenService.java
+++ b/backend/src/main/java/lost42/backend/common/redis/refreshtoken/RefreshTokenService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import lost42.backend.common.jwt.provider.TokenProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import javax.annotation.PostConstruct;
 import javax.crypto.SecretKey;

--- a/backend/src/main/java/lost42/backend/common/response/ErrorResponse.java
+++ b/backend/src/main/java/lost42/backend/common/response/ErrorResponse.java
@@ -1,4 +1,4 @@
-package lost42.backend.common.Response;
+package lost42.backend.common.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;

--- a/backend/src/main/java/lost42/backend/common/response/FailureResponse.java
+++ b/backend/src/main/java/lost42/backend/common/response/FailureResponse.java
@@ -1,4 +1,4 @@
-package lost42.backend.common.Response;
+package lost42.backend.common.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;

--- a/backend/src/main/java/lost42/backend/common/response/SuccessResponse.java
+++ b/backend/src/main/java/lost42/backend/common/response/SuccessResponse.java
@@ -1,4 +1,4 @@
-package lost42.backend.common.Response;
+package lost42.backend.common.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;

--- a/backend/src/main/java/lost42/backend/config/QueryDslConfig.java
+++ b/backend/src/main/java/lost42/backend/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package lost42.backend.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/backend/src/main/java/lost42/backend/config/StorageConfig.java
+++ b/backend/src/main/java/lost42/backend/config/StorageConfig.java
@@ -1,0 +1,29 @@
+package lost42.backend.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class StorageConfig {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretAccessKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 s3Client() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretAccessKey);
+        return AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+}

--- a/backend/src/main/java/lost42/backend/config/security/SecurityConfig.java
+++ b/backend/src/main/java/lost42/backend/config/security/SecurityConfig.java
@@ -38,7 +38,8 @@ public class SecurityConfig {
             "/api/v1/members/signup",
             "/api/v1/members/reset-password", "/api/v1/members/signin",
             "/api/v1/jwt/test",
-            "/api/v1/members/find-email", "/api/v1/members/find-password", "/api/v1/members/auth"
+            "/api/v1/members/find-email", "/api/v1/members/find-password", "/api/v1/members/auth",
+            "/api/v1/boards/get"
     };
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {

--- a/backend/src/main/java/lost42/backend/config/security/SecurityConfig.java
+++ b/backend/src/main/java/lost42/backend/config/security/SecurityConfig.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -23,6 +24,9 @@ import java.util.Arrays;
 
 @Configuration
 @EnableWebSecurity
+@EnableGlobalMethodSecurity(
+        prePostEnabled = true
+)
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
@@ -31,16 +35,16 @@ public class SecurityConfig {
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
     private final AuthenticationConfiguration authenticationConfiguration;
     private final JwtSecurity jwtSecurity;
-    private final String[] ignoreUrl = {
-            "/", "/favicon.ico",
-            "/oauth2/**", "/login/oauth2/**",
-            "/swagger", "/swagger-ui/**", "/v3/api-docs/**",
-            "/api/v1/members/signup",
-            "/api/v1/members/reset-password", "/api/v1/members/signin",
-            "/api/v1/jwt/test",
-            "/api/v1/members/find-email", "/api/v1/members/find-password", "/api/v1/members/auth",
-            "/api/v1/boards/get"
-    };
+//    private final String[] ignoreUrl = {
+//            "/", "/favicon.ico",
+//            "/oauth2/**", "/login/oauth2/**",
+//            "/swagger", "/swagger-ui/**", "/v3/api-docs/**",
+//            "/api/v1/members/signup",
+//            "/api/v1/members/reset-password", "/api/v1/members/signin",
+//            "/api/v1/jwt/test",
+//            "/api/v1/members/find-email", "/api/v1/members/find-password", "/api/v1/members/auth",
+//            "/api/v1/boards/get"
+//    };
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity.csrf().disable()
@@ -61,10 +65,10 @@ public class SecurityConfig {
                     .invalidateHttpSession(true)
                     .deleteCookies("JSESSIONID")
                 .and()
-                .authorizeRequests(authorize ->
-                        authorize.antMatchers(ignoreUrl).permitAll()
-                                .anyRequest().authenticated()
-                )
+//                .authorizeRequests(authorize ->
+//                        authorize.antMatchers(ignoreUrl).permitAll()
+//                                .anyRequest().authenticated()
+//                )
                 .apply(jwtSecurity)
                 .and()
                 .oauth2Login()

--- a/backend/src/main/java/lost42/backend/config/security/WebMvcConfig.java
+++ b/backend/src/main/java/lost42/backend/config/security/WebMvcConfig.java
@@ -1,0 +1,15 @@
+package lost42.backend.config.security;
+
+import lost42.backend.common.jwt.interceptor.JwtTokenValidationInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new JwtTokenValidationInterceptor());
+    }
+}

--- a/backend/src/main/java/lost42/backend/domain/board/controller/BoardController.java
+++ b/backend/src/main/java/lost42/backend/domain/board/controller/BoardController.java
@@ -3,6 +3,7 @@ package lost42.backend.domain.board.controller;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import lost42.backend.common.jwt.JwtTokenValidation;
 import lost42.backend.common.response.SuccessResponse;
 import lost42.backend.common.auth.dto.CustomUserDetails;
 import lost42.backend.domain.board.dto.ChangeTypeReq;
@@ -30,6 +31,7 @@ public class BoardController {
     }
 
     // 상세 글 조회
+    @JwtTokenValidation
     @GetMapping("/getUser")
     public ResponseEntity<?> getUserContent(@RequestParam Long boardId, @AuthenticationPrincipal @Parameter(hidden = true) CustomUserDetails securityUser) {
         return ResponseEntity.ok().body(SuccessResponse.from(boardService.getContent(boardId, securityUser)));
@@ -41,21 +43,25 @@ public class BoardController {
     }
 
     // 게시글 작성
+    @JwtTokenValidation
     @PostMapping("/add")
     public ResponseEntity<?> createContent(@Valid @RequestBody CreateContentReq req, @AuthenticationPrincipal @Parameter(hidden = true) CustomUserDetails securityUser) {
         return ResponseEntity.ok().body(SuccessResponse.from(boardService.createContent(req, securityUser)));
     }
 
+    @JwtTokenValidation
     @PatchMapping("/update")
     public ResponseEntity<?> updateContent(@Valid @RequestBody UpdateContentReq req, @AuthenticationPrincipal @Parameter(hidden = true) CustomUserDetails securityUser) {
         return ResponseEntity.ok().body(SuccessResponse.from(boardService.updateContent(req, securityUser)));
     }
 
+    @JwtTokenValidation
     @PatchMapping("/type")
     public ResponseEntity<?> changeType(@Valid @RequestBody ChangeTypeReq req, @AuthenticationPrincipal @Parameter(hidden = true) CustomUserDetails securityUser) {
         return ResponseEntity.ok().body(SuccessResponse.from(boardService.changeType(req, securityUser)));
     }
 
+    @JwtTokenValidation
     @DeleteMapping("/delete")
     public ResponseEntity<?> deleteContent(@RequestParam Long boardId, @AuthenticationPrincipal @Parameter(hidden = true) CustomUserDetails securityUser) {
         boardService.deleteContent(boardId, securityUser);

--- a/backend/src/main/java/lost42/backend/domain/board/controller/BoardController.java
+++ b/backend/src/main/java/lost42/backend/domain/board/controller/BoardController.java
@@ -1,4 +1,65 @@
 package lost42.backend.domain.board.controller;
 
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lost42.backend.common.Response.SuccessResponse;
+import lost42.backend.common.auth.dto.CustomUserDetails;
+import lost42.backend.domain.board.dto.ChangeTypeReq;
+import lost42.backend.domain.board.dto.CreateContentReq;
+import lost42.backend.domain.board.dto.GetBoardReq;
+import lost42.backend.domain.board.dto.UpdateContentReq;
+import lost42.backend.domain.board.service.BoardService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.Optional;
+
+@RestController
+@AllArgsConstructor
+@Slf4j
+@RequestMapping("/api/v1/boards")
 public class BoardController {
+    private final BoardService boardService;
+
+    // 게시글 조회
+//    @PostMapping("")
+//    public ResponseEntity<?> getBoards(@Valid @RequestBody GetBoardReq req) {
+//        return ResponseEntity.ok().body(boardService.getBoards(req));
+//    }
+
+    // 상세 글 조회
+    @GetMapping("/getUser")
+    public ResponseEntity<?> getUserContent(@RequestParam Long boardId, @AuthenticationPrincipal @Parameter(hidden = true) CustomUserDetails securityUser) {
+        return ResponseEntity.ok().body(SuccessResponse.from(boardService.getContent(boardId, securityUser)));
+    }
+
+    @GetMapping("/getGuest")
+    public ResponseEntity<?> getGuestContent(@RequestParam Long boardId) {
+        return ResponseEntity.ok().body(SuccessResponse.from(boardService.getGuestContent(boardId)));
+    }
+
+    // 게시글 작성
+    @PostMapping("/add")
+    public ResponseEntity<?> createContent(@Valid @RequestBody CreateContentReq req, @AuthenticationPrincipal @Parameter(hidden = true) CustomUserDetails securityUser) {
+        return ResponseEntity.ok().body(SuccessResponse.from(boardService.createContent(req, securityUser)));
+    }
+
+    @PatchMapping("/update")
+    public ResponseEntity<?> updateContent(@Valid @RequestBody UpdateContentReq req, @AuthenticationPrincipal @Parameter(hidden = true) CustomUserDetails securityUser) {
+        return ResponseEntity.ok().body(SuccessResponse.from(boardService.updateContent(req, securityUser)));
+    }
+
+    @PatchMapping("/type")
+    public ResponseEntity<?> changeType(@Valid @RequestBody ChangeTypeReq req, @AuthenticationPrincipal @Parameter(hidden = true) CustomUserDetails securityUser) {
+        return ResponseEntity.ok().body(SuccessResponse.from(boardService.changeType(req, securityUser)));
+    }
+
+    @DeleteMapping("/delete")
+    public ResponseEntity<?> deleteContent(@RequestParam Long boardId, @AuthenticationPrincipal @Parameter(hidden = true) CustomUserDetails securityUser) {
+        boardService.deleteContent(boardId, securityUser);
+        return ResponseEntity.ok().body(SuccessResponse.noContent());
+    }
 }

--- a/backend/src/main/java/lost42/backend/domain/board/controller/BoardController.java
+++ b/backend/src/main/java/lost42/backend/domain/board/controller/BoardController.java
@@ -11,9 +11,11 @@ import lost42.backend.domain.board.dto.CreateContentReq;
 import lost42.backend.domain.board.dto.GetBoardReq;
 import lost42.backend.domain.board.dto.UpdateContentReq;
 import lost42.backend.domain.board.service.BoardService;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
 
@@ -44,9 +46,12 @@ public class BoardController {
 
     // 게시글 작성
     @JwtTokenValidation
-    @PostMapping("/add")
-    public ResponseEntity<?> createContent(@Valid @RequestBody CreateContentReq req, @AuthenticationPrincipal @Parameter(hidden = true) CustomUserDetails securityUser) {
-        return ResponseEntity.ok().body(SuccessResponse.from(boardService.createContent(req, securityUser)));
+    @PostMapping(value = "/add", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE}) // 이미지 파일도 같이 받기 위해 변경
+    public ResponseEntity<?> createContent(
+            @Valid @RequestPart(name = "data") CreateContentReq req,
+            @RequestPart(name = "boardImage", required = false) MultipartFile image,
+            @AuthenticationPrincipal @Parameter(hidden = true) CustomUserDetails securityUser) {
+        return ResponseEntity.ok().body(SuccessResponse.from(boardService.createContent(req, image, securityUser)));
     }
 
     @JwtTokenValidation

--- a/backend/src/main/java/lost42/backend/domain/board/controller/BoardController.java
+++ b/backend/src/main/java/lost42/backend/domain/board/controller/BoardController.java
@@ -3,7 +3,7 @@ package lost42.backend.domain.board.controller;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import lost42.backend.common.Response.SuccessResponse;
+import lost42.backend.common.response.SuccessResponse;
 import lost42.backend.common.auth.dto.CustomUserDetails;
 import lost42.backend.domain.board.dto.ChangeTypeReq;
 import lost42.backend.domain.board.dto.CreateContentReq;
@@ -15,7 +15,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-import java.util.Optional;
 
 @RestController
 @AllArgsConstructor
@@ -25,10 +24,10 @@ public class BoardController {
     private final BoardService boardService;
 
     // 게시글 조회
-//    @PostMapping("")
-//    public ResponseEntity<?> getBoards(@Valid @RequestBody GetBoardReq req) {
-//        return ResponseEntity.ok().body(boardService.getBoards(req));
-//    }
+    @PostMapping("")
+    public ResponseEntity<?> getBoards(@Valid @RequestBody GetBoardReq req) {
+        return ResponseEntity.ok().body(SuccessResponse.from(boardService.getBoards(req)));
+    }
 
     // 상세 글 조회
     @GetMapping("/getUser")

--- a/backend/src/main/java/lost42/backend/domain/board/converter/BoardStatusConverter.java
+++ b/backend/src/main/java/lost42/backend/domain/board/converter/BoardStatusConverter.java
@@ -1,6 +1,7 @@
-package lost42.backend.domain.board.entity;
+package lost42.backend.domain.board.converter;
 
 import lombok.Getter;
+import lost42.backend.domain.board.entity.BoardStatus;
 
 import javax.persistence.AttributeConverter;
 

--- a/backend/src/main/java/lost42/backend/domain/board/converter/BoardTypeConverter.java
+++ b/backend/src/main/java/lost42/backend/domain/board/converter/BoardTypeConverter.java
@@ -1,6 +1,7 @@
-package lost42.backend.domain.board.entity;
+package lost42.backend.domain.board.converter;
 
 import lombok.Getter;
+import lost42.backend.domain.board.entity.BoardType;
 
 import javax.persistence.AttributeConverter;
 

--- a/backend/src/main/java/lost42/backend/domain/board/dto/ChangeTypeReq.java
+++ b/backend/src/main/java/lost42/backend/domain/board/dto/ChangeTypeReq.java
@@ -1,0 +1,9 @@
+package lost42.backend.domain.board.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ChangeTypeReq {
+    private Long boardId;
+    private String boardType;
+}

--- a/backend/src/main/java/lost42/backend/domain/board/dto/CreateContentReq.java
+++ b/backend/src/main/java/lost42/backend/domain/board/dto/CreateContentReq.java
@@ -1,0 +1,29 @@
+package lost42.backend.domain.board.dto;
+
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@Getter
+public class CreateContentReq {
+    @NotBlank
+    private String boardName;
+
+    private String boardImage;
+
+    @NotBlank
+    private String boardFoundAt;
+
+    @NotBlank
+    private String boardFoundDate;
+
+    @NotBlank
+    private String boardKeepingAt;
+
+    private String boardDescription;
+
+    @NotNull
+    private String boardType;
+}

--- a/backend/src/main/java/lost42/backend/domain/board/dto/CreateContentReq.java
+++ b/backend/src/main/java/lost42/backend/domain/board/dto/CreateContentReq.java
@@ -1,7 +1,9 @@
 package lost42.backend.domain.board.dto;
 
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -9,9 +11,8 @@ import javax.validation.constraints.NotNull;
 @Getter
 public class CreateContentReq {
     @NotBlank
+    @Schema(description = "글 제목", example = "게시글 테스트")
     private String boardName;
-
-    private String boardImage;
 
     @NotBlank
     private String boardFoundAt;

--- a/backend/src/main/java/lost42/backend/domain/board/dto/CreateContentRes.java
+++ b/backend/src/main/java/lost42/backend/domain/board/dto/CreateContentRes.java
@@ -1,0 +1,17 @@
+package lost42.backend.domain.board.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lost42.backend.domain.board.entity.Board;
+
+@Builder
+@Getter
+public class CreateContentRes {
+    private Long boardId;
+
+    public static CreateContentRes from(Board newContent) {
+        return CreateContentRes.builder()
+                .boardId(newContent.getBoardId())
+                .build();
+    }
+}

--- a/backend/src/main/java/lost42/backend/domain/board/dto/GetBoardReq.java
+++ b/backend/src/main/java/lost42/backend/domain/board/dto/GetBoardReq.java
@@ -23,5 +23,5 @@ public class GetBoardReq {
     private String managedNumber;
     private String status;
     private String type;
-    private String page;
+    private Long page;
 }

--- a/backend/src/main/java/lost42/backend/domain/board/dto/GetBoardReq.java
+++ b/backend/src/main/java/lost42/backend/domain/board/dto/GetBoardReq.java
@@ -2,6 +2,8 @@ package lost42.backend.domain.board.dto;
 
 import lombok.Getter;
 
+import javax.validation.constraints.NotNull;
+
 /**
  *	categoryId: 1,
  * 	name: "아이폰",
@@ -23,5 +25,6 @@ public class GetBoardReq {
     private String managedNumber;
     private String status;
     private String type;
+    @NotNull
     private Long page;
 }

--- a/backend/src/main/java/lost42/backend/domain/board/dto/GetBoardReq.java
+++ b/backend/src/main/java/lost42/backend/domain/board/dto/GetBoardReq.java
@@ -1,0 +1,5 @@
+package lost42.backend.domain.board.dto;
+
+public class GetBoardReq {
+
+}

--- a/backend/src/main/java/lost42/backend/domain/board/dto/GetBoardReq.java
+++ b/backend/src/main/java/lost42/backend/domain/board/dto/GetBoardReq.java
@@ -1,5 +1,27 @@
 package lost42.backend.domain.board.dto;
 
-public class GetBoardReq {
+import lombok.Getter;
 
+/**
+ *	categoryId: 1,
+ * 	name: "아이폰",
+ * 	foundAt: "4클러스터",
+ * 	startDate: "2023-11-13",
+ * 	endDate: "2023-11-13",
+ * 	managedNumber: "123",
+ * 	status: "보관중", "처리 완료", "미해결",
+ * 	type: "FOUND", "STORAGE", "ALL",
+ * 	page: 1
+ */
+@Getter
+public class GetBoardReq {
+    private Long categoryId;
+    private String name;
+    private String foundAt;
+    private String startDate;
+    private String endDate;
+    private String managedNumber;
+    private String status;
+    private String type;
+    private String page;
 }

--- a/backend/src/main/java/lost42/backend/domain/board/dto/GetBoardRes.java
+++ b/backend/src/main/java/lost42/backend/domain/board/dto/GetBoardRes.java
@@ -12,8 +12,8 @@ import java.time.LocalDateTime;
 @Builder
 @Getter
 public class GetBoardRes {
-    private GetBoardRes.ContentRes contentRes;
-    private GetBoardRes.MemberRes memberRes;
+    private GetBoardRes.ContentRes board;
+    private GetBoardRes.MemberRes user;
 
     @Builder
     @Getter
@@ -63,8 +63,8 @@ public class GetBoardRes {
 
     public static GetBoardRes fromContent(Board content) {
         return GetBoardRes.builder()
-                .contentRes(GetBoardRes.ContentRes.from(content))
-                .memberRes(GetBoardRes.MemberRes.fromContent(content))
+                .board(ContentRes.from(content))
+                .user(GetBoardRes.MemberRes.fromContent(content))
                 .build();
     }
 }

--- a/backend/src/main/java/lost42/backend/domain/board/dto/GetBoardRes.java
+++ b/backend/src/main/java/lost42/backend/domain/board/dto/GetBoardRes.java
@@ -2,18 +2,18 @@ package lost42.backend.domain.board.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import lost42.backend.domain.board.entity.Board;
 import lost42.backend.domain.board.entity.BoardStatus;
 import lost42.backend.domain.board.entity.BoardType;
 import lost42.backend.domain.member.entity.MemberRole;
-import lost42.backend.domain.board.entity.Board;
 
 import java.time.LocalDateTime;
 
 @Builder
 @Getter
-public class GetContentRes {
-    private ContentRes contentRes;
-    private MemberRes memberRes;
+public class GetBoardRes {
+    private GetBoardRes.ContentRes contentRes;
+    private GetBoardRes.MemberRes memberRes;
 
     @Builder
     @Getter
@@ -30,8 +30,8 @@ public class GetContentRes {
         private BoardType boardType;
         private LocalDateTime boardCreatedAt;
 
-        public static ContentRes from(Board content) {
-            return ContentRes.builder()
+        public static GetBoardRes.ContentRes from(Board content) {
+            return GetBoardRes.ContentRes.builder()
                     .boardId(content.getBoardId())
                     .boardName(content.getName())
                     .boardImage(content.getImage())
@@ -52,37 +52,19 @@ public class GetContentRes {
     private static class MemberRes {
         private String userName;
         private MemberRole userRole;
-        private Boolean isWriter;
 
-        public static MemberRes fromContentAndWriter(Board content, Boolean isWriter) {
-            return MemberRes.builder()
+        public static GetBoardRes.MemberRes fromContent(Board content) {
+            return GetBoardRes.MemberRes.builder()
                     .userName(content.getMember().getName())
                     .userRole(content.getMember().getRole())
-                    .isWriter(isWriter)
-                    .build();
-        }
-
-        public static MemberRes fromContent(Board content) {
-            return MemberRes.builder()
-                    .userName(content.getMember().getName())
-                    .userRole(content.getMember().getRole())
-                    .isWriter(false)
                     .build();
         }
     }
 
-    public static GetContentRes fromContentAndWriter(Board content, Boolean isWriter) {
-        return GetContentRes.builder()
-                .contentRes(ContentRes.from(content))
-                .memberRes(MemberRes.fromContentAndWriter(content, isWriter))
+    public static GetBoardRes fromContent(Board content) {
+        return GetBoardRes.builder()
+                .contentRes(GetBoardRes.ContentRes.from(content))
+                .memberRes(GetBoardRes.MemberRes.fromContent(content))
                 .build();
     }
-
-    public static GetContentRes fromContent(Board content) {
-        return GetContentRes.builder()
-                .contentRes(ContentRes.from(content))
-                .memberRes(MemberRes.fromContent(content))
-                .build();
-    }
-
 }

--- a/backend/src/main/java/lost42/backend/domain/board/dto/GetBoardResDto.java
+++ b/backend/src/main/java/lost42/backend/domain/board/dto/GetBoardResDto.java
@@ -1,0 +1,22 @@
+package lost42.backend.domain.board.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class GetBoardResDto {
+    private List<GetBoardRes> contents;
+    private Long pageNum;
+    private Long totalContents;
+
+    public static GetBoardResDto from(List<GetBoardRes> contents, Long pageNum, Long totalContents) {
+        return GetBoardResDto.builder()
+                .contents(contents)
+                .pageNum(pageNum)
+                .totalContents(totalContents)
+                .build();
+    }
+}

--- a/backend/src/main/java/lost42/backend/domain/board/dto/GetContentRes.java
+++ b/backend/src/main/java/lost42/backend/domain/board/dto/GetContentRes.java
@@ -1,0 +1,86 @@
+package lost42.backend.domain.board.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lost42.backend.domain.member.entity.MemberRole;
+import lost42.backend.domain.board.entity.Board;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class GetContentRes {
+    private ContentRes contentRes;
+    private MemberRes memberRes;
+
+    @Builder
+    @Getter
+    private static class ContentRes {
+        private Long boardId;
+        private String boardName;
+        private String boardImage;
+        private String boardFoundAt;
+        private String boardFoundDate;
+        private String boardKeepingAt;
+        private String boardDescription;
+        private String boardManagedNumber;
+        private String boardStatus;
+        private String boardType;
+        private LocalDateTime boardCreatedAt;
+
+        public static ContentRes from(Board content) {
+            return ContentRes.builder()
+                    .boardId(content.getBoardId())
+                    .boardName(content.getName())
+                    .boardImage(content.getImage())
+                    .boardFoundAt(content.getFoundAt())
+                    .boardFoundDate(content.getFoundDate())
+                    .boardKeepingAt(content.getKeepingAt())
+                    .boardDescription(content.getDescription())
+                    .boardManagedNumber(content.getManagedNumber())
+                    .boardStatus(content.getStatus())
+                    .boardType(content.getType())
+                    .boardCreatedAt(content.getCreatedAt())
+                    .build();
+        }
+    }
+
+    @Builder
+    @Getter
+    private static class MemberRes {
+        private String userName;
+        private MemberRole userRole;
+        private Boolean isWriter;
+
+        public static MemberRes fromContentAndWriter(Board content, Boolean isWriter) {
+            return MemberRes.builder()
+                    .userName(content.getMember().getName())
+                    .userRole(content.getMember().getRole())
+                    .isWriter(isWriter)
+                    .build();
+        }
+
+        public static MemberRes fromContent(Board content) {
+            return MemberRes.builder()
+                    .userName(content.getMember().getName())
+                    .userRole(content.getMember().getRole())
+                    .isWriter(false)
+                    .build();
+        }
+    }
+
+    public static GetContentRes fromContentAndWriter(Board content, Boolean isWriter) {
+        return GetContentRes.builder()
+                .contentRes(ContentRes.from(content))
+                .memberRes(MemberRes.fromContentAndWriter(content, isWriter))
+                .build();
+    }
+
+    public static GetContentRes fromContent(Board content) {
+        return GetContentRes.builder()
+                .contentRes(ContentRes.from(content))
+                .memberRes(MemberRes.fromContent(content))
+                .build();
+    }
+
+}

--- a/backend/src/main/java/lost42/backend/domain/board/dto/UpdateContentReq.java
+++ b/backend/src/main/java/lost42/backend/domain/board/dto/UpdateContentReq.java
@@ -1,0 +1,29 @@
+package lost42.backend.domain.board.dto;
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+
+/**
+ * 	"boardName": "게시글1",
+ * 	"boardImage": multipartform,
+ * 	"boardFoundAt": "7클러스터",
+ * 	"boardFoundDate": "2023-11-10",
+ * 	"boardkeepingAt": "개포 안내 데스크",
+ * 	"boardDescription": "블라블라
+ */
+
+@Getter
+public class UpdateContentReq {
+    private Long BoardId;
+    @NotBlank
+    private String boardName;
+    private String boardImage;
+    @NotBlank
+    private String boardFoundAt;
+    @NotBlank
+    private String boardFoundDate;
+    @NotBlank
+    private String boardKeepingAt;
+    private String boardDescription;
+}

--- a/backend/src/main/java/lost42/backend/domain/board/dto/UpdateContentRes.java
+++ b/backend/src/main/java/lost42/backend/domain/board/dto/UpdateContentRes.java
@@ -1,0 +1,16 @@
+package lost42.backend.domain.board.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class UpdateContentRes {
+    private Long boardId;
+
+    public static UpdateContentRes success(Long boardId) {
+        return UpdateContentRes.builder()
+                .boardId(boardId)
+                .build();
+    }
+}

--- a/backend/src/main/java/lost42/backend/domain/board/entity/Board.java
+++ b/backend/src/main/java/lost42/backend/domain/board/entity/Board.java
@@ -59,10 +59,12 @@ public class Board extends Auditable {
     private String managedNumber;
 
     @Column(name = "status")
-    private String status; // 추후 enum 으로 변경
+    @Convert(converter = BoardStatusConverter.class)
+    private BoardStatus status;
 
     @Column(name = "type")
-    private String type; // 추후 enum 으로 변경
+    @Convert(converter = BoardTypeConverter.class)
+    private BoardType type;
 
     @Column(name = "deleted_dt")
     private LocalDateTime deletedDt;
@@ -79,7 +81,7 @@ public class Board extends Auditable {
     }
 
     public Board changeType(ChangeTypeReq req) {
-        this.type = req.getBoardType();
+        this.type = BoardType.fromString(req.getBoardType());
         return this;
     }
 

--- a/backend/src/main/java/lost42/backend/domain/board/entity/Board.java
+++ b/backend/src/main/java/lost42/backend/domain/board/entity/Board.java
@@ -2,11 +2,19 @@ package lost42.backend.domain.board.entity;
 
 import lombok.*;
 import lost42.backend.config.Auditable;
+import lost42.backend.domain.board.dto.ChangeTypeReq;
+import lost42.backend.domain.board.dto.UpdateContentReq;
+import lost42.backend.domain.category.entity.BoardCategory;
+import lost42.backend.domain.category.entity.Category;
+import lost42.backend.domain.member.entity.Member;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
+@Table(name = "BOARD")
 @Getter
 @Builder
 @AllArgsConstructor
@@ -17,6 +25,14 @@ public class Board extends Auditable {
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "board_id")
     private Long boardId;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "board")
+    private List<BoardCategory> boardCategories = new ArrayList<>();
 
     @Column(name = "name", length = 50, nullable = false)
     private String name;
@@ -51,4 +67,24 @@ public class Board extends Auditable {
     @Column(name = "deleted_dt")
     private LocalDateTime deletedDt;
 
+    public Board updateContent(UpdateContentReq req) {
+        this.name = req.getBoardName();
+        this.image = req.getBoardImage();
+        this.foundAt = req.getBoardFoundAt();
+        this.foundDate = req.getBoardFoundDate();
+        this.keepingAt = req.getBoardKeepingAt();
+        this.description = req.getBoardDescription();
+
+        return this;
+    }
+
+    public Board changeType(ChangeTypeReq req) {
+        this.type = req.getBoardType();
+        return this;
+    }
+
+    public Board deleteContent() {
+        this.deletedDt = LocalDateTime.now();
+        return this;
+    }
 }

--- a/backend/src/main/java/lost42/backend/domain/board/entity/Board.java
+++ b/backend/src/main/java/lost42/backend/domain/board/entity/Board.java
@@ -2,10 +2,11 @@ package lost42.backend.domain.board.entity;
 
 import lombok.*;
 import lost42.backend.config.Auditable;
+import lost42.backend.domain.board.converter.BoardStatusConverter;
+import lost42.backend.domain.board.converter.BoardTypeConverter;
 import lost42.backend.domain.board.dto.ChangeTypeReq;
 import lost42.backend.domain.board.dto.UpdateContentReq;
 import lost42.backend.domain.category.entity.BoardCategory;
-import lost42.backend.domain.category.entity.Category;
 import lost42.backend.domain.member.entity.Member;
 
 import javax.persistence.*;

--- a/backend/src/main/java/lost42/backend/domain/board/entity/BoardStatus.java
+++ b/backend/src/main/java/lost42/backend/domain/board/entity/BoardStatus.java
@@ -1,0 +1,4 @@
+package lost42.backend.domain.board.entity;
+
+public enum BoardStatus {
+}

--- a/backend/src/main/java/lost42/backend/domain/board/entity/BoardStatus.java
+++ b/backend/src/main/java/lost42/backend/domain/board/entity/BoardStatus.java
@@ -1,4 +1,20 @@
 package lost42.backend.domain.board.entity;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum BoardStatus {
+    ING("1", "진행 중"),
+    END("2", "완료"),
+    DELETE("3", "폐기");
+
+    private final String code;
+    private final String status;
+
+    @Override
+    public String toString() {
+        return String.format("Status: %s", this.status);
+    }
 }

--- a/backend/src/main/java/lost42/backend/domain/board/entity/BoardStatusConverter.java
+++ b/backend/src/main/java/lost42/backend/domain/board/entity/BoardStatusConverter.java
@@ -1,0 +1,30 @@
+package lost42.backend.domain.board.entity;
+
+import lombok.Getter;
+
+import javax.persistence.AttributeConverter;
+
+@Getter
+public class BoardStatusConverter implements AttributeConverter<BoardStatus, String> {
+
+    @Override
+    public String convertToDatabaseColumn(BoardStatus attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        return attribute.getCode();
+    }
+
+    @Override
+    public BoardStatus convertToEntityAttribute(String dbData) {
+        if (dbData == null) {
+            return null;
+        }
+        for (BoardStatus boardStatus : BoardStatus.values()) {
+            if (boardStatus.getCode().equals(dbData)) {
+                return boardStatus;
+            }
+        }
+        throw new IllegalArgumentException("Unknown database value: " + dbData);
+    }
+}

--- a/backend/src/main/java/lost42/backend/domain/board/entity/BoardType.java
+++ b/backend/src/main/java/lost42/backend/domain/board/entity/BoardType.java
@@ -1,4 +1,27 @@
 package lost42.backend.domain.board.entity;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum BoardType {
+    FIND("1", "찾습니다"),
+    KEEP("2", "보관중입니다");
+
+    private final String code;
+    private final String type;
+
+    @Override
+    public String toString() {
+        return String.format("Type: %s", this.type);
+    }
+
+    public static BoardType fromString(String type) {
+        for (BoardType boardType : BoardType.values()) {
+            if (boardType.getType().equals(type))
+                return boardType;
+        }
+        throw new IllegalArgumentException("Invalid BoardType: " + type);
+    }
 }

--- a/backend/src/main/java/lost42/backend/domain/board/entity/BoardType.java
+++ b/backend/src/main/java/lost42/backend/domain/board/entity/BoardType.java
@@ -1,0 +1,4 @@
+package lost42.backend.domain.board.entity;
+
+public enum BoardType {
+}

--- a/backend/src/main/java/lost42/backend/domain/board/entity/BoardTypeConverter.java
+++ b/backend/src/main/java/lost42/backend/domain/board/entity/BoardTypeConverter.java
@@ -1,0 +1,30 @@
+package lost42.backend.domain.board.entity;
+
+import lombok.Getter;
+
+import javax.persistence.AttributeConverter;
+
+@Getter
+public class BoardTypeConverter implements AttributeConverter<BoardType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(BoardType attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        return attribute.getCode();
+    }
+
+    @Override
+    public BoardType convertToEntityAttribute(String dbData) {
+        if (dbData == null) {
+            return null;
+        }
+        for (BoardType boardType : BoardType.values()) {
+            if (boardType.getCode().equals(dbData)) {
+                return boardType;
+            }
+        }
+        throw new IllegalArgumentException("Unknown database value: " + dbData);
+    }
+}

--- a/backend/src/main/java/lost42/backend/domain/board/exception/BoardErrorCode.java
+++ b/backend/src/main/java/lost42/backend/domain/board/exception/BoardErrorCode.java
@@ -14,7 +14,12 @@ public enum BoardErrorCode implements StatusCode {
     /**
      * 400 BAD_REQUEST
      */
-    INVALID_CONTENT(BAD_REQUEST, "게시글이 존재하지 않습니다.");
+    INVALID_CONTENT(BAD_REQUEST, "게시글이 존재하지 않습니다."),
+
+    /**
+     * 401 UNAUTORIZED
+     */
+    USER_MISS_MATCH(UNAUTHORIZED, "수정 권한이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/backend/src/main/java/lost42/backend/domain/board/exception/BoardErrorCode.java
+++ b/backend/src/main/java/lost42/backend/domain/board/exception/BoardErrorCode.java
@@ -1,0 +1,21 @@
+package lost42.backend.domain.board.exception;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lost42.backend.common.code.StatusCode;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public enum BoardErrorCode implements StatusCode {
+    /**
+     * 400 BAD_REQUEST
+     */
+    INVALID_CONTENT(BAD_REQUEST, "게시글이 존재하지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/backend/src/main/java/lost42/backend/domain/board/exception/BoardErrorException.java
+++ b/backend/src/main/java/lost42/backend/domain/board/exception/BoardErrorException.java
@@ -1,0 +1,19 @@
+package lost42.backend.domain.board.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BoardErrorException extends RuntimeException {
+    private final BoardErrorCode errorCode;
+
+    public BoardErrorException(BoardErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("BoardErrorException(code=%s, message=%s)",
+                errorCode.name(), errorCode.getMessage());
+    }
+}

--- a/backend/src/main/java/lost42/backend/domain/board/repository/BoardRepository.java
+++ b/backend/src/main/java/lost42/backend/domain/board/repository/BoardRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface BoardRepository extends JpaRepository<Board, Long> {
+public interface BoardRepository extends JpaRepository<Board, Long>, BoardRepositoryCustom {
 }

--- a/backend/src/main/java/lost42/backend/domain/board/repository/BoardRepositoryCustom.java
+++ b/backend/src/main/java/lost42/backend/domain/board/repository/BoardRepositoryCustom.java
@@ -5,6 +5,10 @@ import lost42.backend.domain.board.entity.Board;
 
 import java.util.List;
 
+/**
+ * 구현체 : BoardRepositoryImpl
+ * QueryDsl 을 사용하기 위한 Custom Repository 적용
+ */
 public interface BoardRepositoryCustom {
     List<Board> findAllContents(GetBoardReq req);
 }

--- a/backend/src/main/java/lost42/backend/domain/board/repository/BoardRepositoryCustom.java
+++ b/backend/src/main/java/lost42/backend/domain/board/repository/BoardRepositoryCustom.java
@@ -1,0 +1,10 @@
+package lost42.backend.domain.board.repository;
+
+import lost42.backend.domain.board.dto.GetBoardReq;
+import lost42.backend.domain.board.entity.Board;
+
+import java.util.List;
+
+public interface BoardRepositoryCustom {
+    List<Board> findAllContents(GetBoardReq req);
+}

--- a/backend/src/main/java/lost42/backend/domain/board/repository/BoardRepositoryCustom.java
+++ b/backend/src/main/java/lost42/backend/domain/board/repository/BoardRepositoryCustom.java
@@ -2,13 +2,13 @@ package lost42.backend.domain.board.repository;
 
 import lost42.backend.domain.board.dto.GetBoardReq;
 import lost42.backend.domain.board.entity.Board;
-
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 /**
  * 구현체 : BoardRepositoryImpl
  * QueryDsl 을 사용하기 위한 Custom Repository 적용
  */
 public interface BoardRepositoryCustom {
-    List<Board> findAllContents(GetBoardReq req);
+    Page<Board> findAllContents(GetBoardReq req, Pageable pageable);
 }

--- a/backend/src/main/java/lost42/backend/domain/board/repository/BoardRepositoryImpl.java
+++ b/backend/src/main/java/lost42/backend/domain/board/repository/BoardRepositoryImpl.java
@@ -1,0 +1,71 @@
+package lost42.backend.domain.board.repository;
+
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lost42.backend.domain.board.dto.GetBoardReq;
+import lost42.backend.domain.board.entity.Board;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import static lost42.backend.domain.board.entity.QBoard.board;
+import static lost42.backend.domain.category.entity.QBoardCategory.boardCategory;
+import static lost42.backend.domain.category.entity.QCategory.category;
+
+
+@RequiredArgsConstructor
+public class BoardRepositoryImpl implements BoardRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<Board> findAllContents(GetBoardReq req) {
+        return jpaQueryFactory.selectFrom(board)
+                .where(allCondition(req))
+                .fetch();
+    }
+
+    private BooleanBuilder allCondition(GetBoardReq req) {
+        BooleanBuilder booleanBuilder = new BooleanBuilder();
+        return booleanBuilder
+                .and(categoryEq(req.getCategoryId()))
+                .and(nameEq(req.getName()))
+                .and(foundAtEq(req.getFoundAt()))
+                .and(managedNumberEq(req.getManagedNumber()))
+                .and(withIn(req.getStartDate(), req.getEndDate()));
+    }
+
+    private BooleanExpression categoryEq(Long categoryId) {
+        return categoryId != null ? boardCategory.category.categoryId.eq(categoryId) : null;
+    }
+
+    private BooleanExpression nameEq(String name) {
+        return StringUtils.hasText(name) ? board.name.eq(name) : null;
+    }
+
+    private BooleanExpression foundAtEq(String foundAt) {
+        return StringUtils.hasText(foundAt) ? board.foundAt.eq(foundAt) : null;
+    }
+
+    private BooleanExpression managedNumberEq(String managedNumber) {
+        return StringUtils.hasText(managedNumber) ? board.managedNumber.eq(managedNumber) : null;
+    }
+
+    private BooleanExpression withIn(String startDate, String endDate) {
+        if (startDate != null && endDate != null) {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+            LocalDateTime startDateTime = LocalDateTime.parse(startDate, formatter);
+            LocalDateTime endDateTime = LocalDateTime.parse(endDate, formatter);
+
+            return board.createdAt.between(startDateTime, endDateTime);
+        } else {
+            return null;
+        }
+    }
+}

--- a/backend/src/main/java/lost42/backend/domain/board/repository/BoardRepositoryImpl.java
+++ b/backend/src/main/java/lost42/backend/domain/board/repository/BoardRepositoryImpl.java
@@ -4,9 +4,13 @@ package lost42.backend.domain.board.repository;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import lombok.RequiredArgsConstructor;
 import lost42.backend.domain.board.dto.GetBoardReq;
 import lost42.backend.domain.board.entity.Board;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
@@ -18,16 +22,26 @@ import static lost42.backend.domain.category.entity.QBoardCategory.boardCategory
 import static lost42.backend.domain.category.entity.QCategory.category;
 
 
-@RequiredArgsConstructor
-public class BoardRepositoryImpl implements BoardRepositoryCustom {
+@Repository
+public class BoardRepositoryImpl extends QuerydslRepositorySupport implements BoardRepositoryCustom {
 
     private final JPAQueryFactory jpaQueryFactory;
 
+    public BoardRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+        super(Board.class);
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
+
     @Override
-    public List<Board> findAllContents(GetBoardReq req) {
-        return jpaQueryFactory.selectFrom(board)
+    public Page<Board> findAllContents(GetBoardReq req, Pageable pageable) {
+        List<Board> result = jpaQueryFactory.selectFrom(board)
                 .where(allCondition(req))
+                .orderBy(board.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
                 .fetch();
+
+        return new PageImpl<>(result, pageable, count(req));
     }
 
     private BooleanBuilder allCondition(GetBoardReq req) {
@@ -37,7 +51,8 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom {
                 .and(nameEq(req.getName()))
                 .and(foundAtEq(req.getFoundAt()))
                 .and(managedNumberEq(req.getManagedNumber()))
-                .and(withIn(req.getStartDate(), req.getEndDate()));
+                .and(withIn(req.getStartDate(), req.getEndDate()))
+                .and(deletedDtIsNull());
     }
 
     private BooleanExpression categoryEq(Long categoryId) {
@@ -67,5 +82,15 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom {
         } else {
             return null;
         }
+    }
+
+    private BooleanExpression deletedDtIsNull() {
+        return board.deletedDt.isNull();
+    }
+
+    private Long count(GetBoardReq req) {
+        return jpaQueryFactory.selectFrom(board)
+                .where(allCondition(req))
+                .fetchCount();
     }
 }

--- a/backend/src/main/java/lost42/backend/domain/board/repository/BoardRepositoryImpl.java
+++ b/backend/src/main/java/lost42/backend/domain/board/repository/BoardRepositoryImpl.java
@@ -45,7 +45,7 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom {
     }
 
     private BooleanExpression nameEq(String name) {
-        return StringUtils.hasText(name) ? board.name.eq(name) : null;
+        return StringUtils.hasText(name) ? board.name.contains(name) : null;
     }
 
     private BooleanExpression foundAtEq(String foundAt) {

--- a/backend/src/main/java/lost42/backend/domain/board/service/BoardService.java
+++ b/backend/src/main/java/lost42/backend/domain/board/service/BoardService.java
@@ -29,8 +29,11 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -83,8 +86,9 @@ public class BoardService {
 
         String imageUrl = null;
 
-        if (!image.isEmpty()) {
-            imageUrl = uploadImage(image, req.getBoardName());
+        if (image != null) {
+            String variable = req.getBoardName() + LocalDate.now(); // bucket 에 저장되는 이미지 : 게시글 제목 + 현재 날짜
+            imageUrl = uploadImage(image, variable);
         }
 
         Board newContent = Board.builder()

--- a/backend/src/main/java/lost42/backend/domain/board/service/BoardService.java
+++ b/backend/src/main/java/lost42/backend/domain/board/service/BoardService.java
@@ -1,0 +1,111 @@
+package lost42.backend.domain.board.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lost42.backend.domain.member.entity.MemberRole;
+import lost42.backend.common.auth.dto.CustomUserDetails;
+import lost42.backend.domain.board.dto.*;
+import lost42.backend.domain.board.entity.Board;
+import lost42.backend.domain.board.repository.BoardRepository;
+import lost42.backend.domain.member.entity.Member;
+import lost42.backend.domain.member.exception.MemberErrorCode;
+import lost42.backend.domain.member.exception.MemberErrorException;
+import lost42.backend.domain.member.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BoardService {
+
+    private final BoardRepository boardRepository;
+    private final MemberRepository memberRepository;
+
+//    public Object getBoards(GetBoardReq req) {
+//
+//    }
+
+    public GetContentRes getContent(Long boardId, CustomUserDetails securityUser) {
+        Board content = boardRepository.findById(boardId).orElse(null);
+
+        Boolean isWriter = content.getMember().getMemberId() == securityUser.getMemberId();
+        return GetContentRes.fromContentAndWriter(content, isWriter);
+    }
+
+    public GetContentRes getGuestContent(Long boardId) {
+        Board content = boardRepository.findById(boardId).orElse(null);
+
+        return GetContentRes.fromContent(content);
+    }
+
+    public CreateContentRes createContent(CreateContentReq req, CustomUserDetails securityUser) {
+        Member member = memberRepository.findById(securityUser.getMemberId())
+                .orElseThrow(() -> new MemberErrorException(MemberErrorCode.INVALID_USER));
+
+        Board newContent = Board.builder()
+                .member(member)
+                .name(req.getBoardName())
+                .image(req.getBoardImage())
+                .foundAt(req.getBoardFoundAt())
+                .foundDate(req.getBoardFoundDate())
+                .keepingAt(req.getBoardKeepingAt())
+                .description(req.getBoardDescription())
+                .managedNumber("123123") // 추후 enum 클래스로 변경
+                .status("보관 중") // 추후 enum 클래스로 변경 변경
+                .type(req.getBoardType())
+                .build();
+
+        boardRepository.save(newContent);
+
+        return CreateContentRes.from(newContent);
+    }
+
+    public UpdateContentRes updateContent(UpdateContentReq req, CustomUserDetails securityUser) {
+        Board content = boardRepository.findById(req.getBoardId()).orElse(null);
+        Member member = memberRepository.findById(securityUser.getMemberId())
+                .orElseThrow(() -> new MemberErrorException(MemberErrorCode.INVALID_USER));
+
+        if (!member.getRole().equals(MemberRole.ADMIN) && content.getMember().getMemberId() != member.getMemberId()) {
+            throw new RuntimeException("수정 권한 없음");
+        }
+
+        content.updateContent(req);
+
+        boardRepository.save(content);
+
+        return UpdateContentRes.success(content.getBoardId());
+    }
+
+    public UpdateContentRes changeType(ChangeTypeReq req, CustomUserDetails securityUser) {
+        Board content = boardRepository.findById(req.getBoardId()).orElse(null);
+        Member member = memberRepository.findById(securityUser.getMemberId())
+                .orElseThrow(() -> new MemberErrorException(MemberErrorCode.INVALID_USER));
+
+        if (!member.getRole().equals(MemberRole.ADMIN) && content.getMember().getMemberId() != member.getMemberId()) {
+            throw new RuntimeException("수정 권한 없음");
+        }
+
+        content.changeType(req);
+
+        boardRepository.save(content);
+
+        return UpdateContentRes.success(content.getBoardId());
+    }
+
+    public Boolean deleteContent(Long boardId, CustomUserDetails securityUser) {
+        Board content = boardRepository.findById(boardId).orElse(null);
+        Member member = memberRepository.findById(securityUser.getMemberId())
+                .orElseThrow(() -> new MemberErrorException(MemberErrorCode.INVALID_USER));
+
+        if (!member.getRole().equals(MemberRole.ADMIN) && content.getMember().getMemberId() != member.getMemberId()) {
+            throw new RuntimeException("수정 권한 없음");
+        }
+
+        content.deleteContent();
+
+        boardRepository.save(content);
+
+        return true;
+    }
+
+}

--- a/backend/src/main/java/lost42/backend/domain/category/entity/BoardCategory.java
+++ b/backend/src/main/java/lost42/backend/domain/category/entity/BoardCategory.java
@@ -1,0 +1,29 @@
+package lost42.backend.domain.category.entity;
+
+import lombok.*;
+import lost42.backend.config.Auditable;
+import lost42.backend.domain.board.entity.Board;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "BOARD_CATEGORY")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class BoardCategory extends Auditable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "board_id")
+    private Board board;
+
+    @ManyToOne
+    @JoinColumn(name = "category_id")
+    private Category category;
+}

--- a/backend/src/main/java/lost42/backend/domain/category/entity/Category.java
+++ b/backend/src/main/java/lost42/backend/domain/category/entity/Category.java
@@ -2,9 +2,12 @@ package lost42.backend.domain.category.entity;
 
 import lombok.*;
 import lost42.backend.config.Auditable;
+import lost42.backend.domain.board.entity.Board;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -17,6 +20,11 @@ public class Category extends Auditable {
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "category_id")
     private Long categoryId;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "category")
+    private List<BoardCategory> boardCategories = new ArrayList<>();
+
 
     @Column(name = "name", length = 50, nullable = false)
     private String name;

--- a/backend/src/main/java/lost42/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/lost42/backend/domain/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package lost42.backend.domain.member.controller;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import lost42.backend.common.jwt.JwtTokenValidation;
 import lost42.backend.common.response.FailureResponse;
 import lost42.backend.common.response.SuccessResponse;
 import lost42.backend.common.auth.dto.CustomUserDetails;
@@ -16,6 +17,7 @@ import lost42.backend.domain.member.service.SignUpService;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -34,6 +36,8 @@ public class MemberController {
     private final EmailService emailService;
     private final AuthTokenService authTokenService;
 
+    @JwtTokenValidation // 필요할까??? -> token이 없다면 객체 자체가 생성되지 않아 Authentication 객체가 null 인데... 차라리 PreAuthorize를 제외하자
+//    @PreAuthorize("isAuthenticated()")
     @GetMapping("/my")
     public ResponseEntity<?> getUserInfo(@AuthenticationPrincipal @Parameter(hidden = true) CustomUserDetails securityUser) {
         return ResponseEntity.ok().body(SuccessResponse.from(memberService.getUserInfo(securityUser)));
@@ -69,6 +73,7 @@ public class MemberController {
         return ResponseEntity.ok().body(response);
     }
 
+    @JwtTokenValidation
     @GetMapping("/auth")
     public ResponseEntity<?> authCheck(@RequestParam("id") Long memberId, @RequestParam("token") String token) {
         authTokenService.validate(memberId, token);
@@ -87,17 +92,20 @@ public class MemberController {
         return ResponseEntity.ok().body(SuccessResponse.from(memberService.resetPassword(name, email, req)));
     }
 
+    @JwtTokenValidation
     @PatchMapping("/change")
     public ResponseEntity<?> changeUserData(@RequestBody ChangeUserDataReq req, @AuthenticationPrincipal @Parameter(hidden = true) CustomUserDetails securityUser) {
         return ResponseEntity.ok().body(SuccessResponse.from(memberService.changeUserData(req, securityUser)));
     }
 
+    @JwtTokenValidation
     @GetMapping("/logout")
     public ResponseEntity<?> logout(@AuthenticationPrincipal @Parameter(hidden = true) CustomUserDetails securityUser) {
         logOutService.logOut(securityUser);
         return ResponseEntity.ok().body(SuccessResponse.noContent());
     }
 
+    @JwtTokenValidation
     @DeleteMapping("/delete")
     public ResponseEntity<?> deleteUser(@AuthenticationPrincipal @Parameter(hidden = true) CustomUserDetails securityUser) {
         return ResponseEntity.ok().body(SuccessResponse.from(memberService.withdrawalMember(securityUser)));

--- a/backend/src/main/java/lost42/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/lost42/backend/domain/member/controller/MemberController.java
@@ -3,10 +3,9 @@ package lost42.backend.domain.member.controller;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import lost42.backend.common.Response.FailureResponse;
-import lost42.backend.common.Response.SuccessResponse;
+import lost42.backend.common.response.FailureResponse;
+import lost42.backend.common.response.SuccessResponse;
 import lost42.backend.common.auth.dto.CustomUserDetails;
-import lost42.backend.common.mail.EmailMessage;
 import lost42.backend.common.mail.EmailService;
 import lost42.backend.common.redis.authToken.AuthTokenService;
 import lost42.backend.domain.member.dto.*;
@@ -20,7 +19,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import javax.mail.MessagingException;
 import javax.validation.Valid;
 
 

--- a/backend/src/main/java/lost42/backend/domain/member/converter/MemberRoleConverter.java
+++ b/backend/src/main/java/lost42/backend/domain/member/converter/MemberRoleConverter.java
@@ -1,0 +1,33 @@
+package lost42.backend.domain.member.converter;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import lost42.backend.domain.member.entity.MemberRole;
+
+import javax.persistence.AttributeConverter;
+
+@Getter
+@Slf4j
+public class MemberRoleConverter implements AttributeConverter<MemberRole, String> {
+
+    @Override
+    public String convertToDatabaseColumn(MemberRole attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        return attribute.getCode();
+    }
+
+    @Override
+    public MemberRole convertToEntityAttribute(String dbData) {
+        if (dbData == null) {
+            return null;
+        }
+        for (MemberRole role : MemberRole.values()) {
+            if (role.getCode().equals(dbData)) {
+                return role;
+            }
+        }
+        throw new IllegalArgumentException("Unknown database value: " + dbData);
+    }
+}

--- a/backend/src/main/java/lost42/backend/domain/member/dto/SignUpRes.java
+++ b/backend/src/main/java/lost42/backend/domain/member/dto/SignUpRes.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lost42.backend.common.auth.MemberRole;
+import lost42.backend.domain.member.entity.MemberRole;
 import lost42.backend.domain.member.entity.Member;
 
 @Builder

--- a/backend/src/main/java/lost42/backend/domain/member/dto/UserInfoRes.java
+++ b/backend/src/main/java/lost42/backend/domain/member/dto/UserInfoRes.java
@@ -1,7 +1,7 @@
 package lost42.backend.domain.member.dto;
 
 import lombok.*;
-import lost42.backend.common.auth.MemberRole;
+import lost42.backend.domain.member.entity.MemberRole;
 import lost42.backend.domain.member.entity.Member;
 
 @Builder

--- a/backend/src/main/java/lost42/backend/domain/member/entity/Member.java
+++ b/backend/src/main/java/lost42/backend/domain/member/entity/Member.java
@@ -2,12 +2,12 @@ package lost42.backend.domain.member.entity;
 
 import lombok.*;
 import lost42.backend.config.Auditable;
-import lost42.backend.common.auth.MemberRole;
+import lost42.backend.domain.board.entity.Board;
 
 import javax.persistence.*;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Date;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -20,6 +20,10 @@ public class Member extends Auditable {
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "member_id")
     private Long memberId;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "member")
+    private List<Board> boards = new ArrayList<>();
 
     @Column(name = "email", length = 50, nullable = false)
     private String email;

--- a/backend/src/main/java/lost42/backend/domain/member/entity/Member.java
+++ b/backend/src/main/java/lost42/backend/domain/member/entity/Member.java
@@ -3,6 +3,7 @@ package lost42.backend.domain.member.entity;
 import lombok.*;
 import lost42.backend.config.Auditable;
 import lost42.backend.domain.board.entity.Board;
+import lost42.backend.domain.member.converter.MemberRoleConverter;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -41,6 +42,7 @@ public class Member extends Auditable {
     private String oauthProvider;
 
     @Column(name = "role", nullable = false)
+    @Convert(converter = MemberRoleConverter.class)
     private MemberRole role;
 
     @Column(name = "deleted_dt")

--- a/backend/src/main/java/lost42/backend/domain/member/entity/Member.java
+++ b/backend/src/main/java/lost42/backend/domain/member/entity/Member.java
@@ -40,9 +40,6 @@ public class Member extends Auditable {
     @Column(name = "oauth_provider", length = 20)
     private String oauthProvider;
 
-    @Column(name = "refresh_token", length = 100)
-    private String refreshToken;
-
     @Column(name = "role", nullable = false)
     private MemberRole role;
 

--- a/backend/src/main/java/lost42/backend/domain/member/entity/MemberRole.java
+++ b/backend/src/main/java/lost42/backend/domain/member/entity/MemberRole.java
@@ -1,4 +1,4 @@
-package lost42.backend.common.auth;
+package lost42.backend.domain.member.entity;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/lost42/backend/domain/member/entity/MemberRole.java
+++ b/backend/src/main/java/lost42/backend/domain/member/entity/MemberRole.java
@@ -6,21 +6,21 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum MemberRole {
-    MEMBER("ROLE_MEMBER", "일반 유저"),
-    ADMIN("ROLE_ADMIN", "관리자");
+    ADMIN("1", "ROLE_ADMIN"),
+    MEMBER("2", "ROLE_MEMBER");
 
-    private final String key;
-    private final String title;
+    private final String code;
+    private final String role;
 
     @Override
     public String toString() {
-        return String.format("role: %s", this.key);
+        return String.format("role: %s", this.role);
     }
 
     public static MemberRole fromString(String key) {
         String roleKey = "ROLE_" + key;
         for (MemberRole role : MemberRole.values()) {
-            if (role.getKey().equals(roleKey)) {
+            if (role.getRole().equals(roleKey)) {
                 return role;
             }
         }

--- a/backend/src/main/java/lost42/backend/domain/member/service/LogInService.java
+++ b/backend/src/main/java/lost42/backend/domain/member/service/LogInService.java
@@ -25,6 +25,7 @@ public class LogInService {
         Authentication authentication = authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(req.getUserEmail(), req.getUserPassword())
         );
+
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
         JwtTokenInfo tokenInfo = JwtTokenInfo.fromCustomUserDetails((CustomUserDetails) authentication.getPrincipal());

--- a/backend/src/main/java/lost42/backend/domain/member/service/SignUpService.java
+++ b/backend/src/main/java/lost42/backend/domain/member/service/SignUpService.java
@@ -2,9 +2,7 @@ package lost42.backend.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import lost42.backend.common.Response.FailureResponse;
-import lost42.backend.common.Response.SuccessResponse;
-import lost42.backend.common.auth.MemberRole;
+import lost42.backend.domain.member.entity.MemberRole;
 import lost42.backend.domain.member.dto.SignUpReq;
 import lost42.backend.domain.member.dto.SignUpRes;
 import lost42.backend.domain.member.entity.Member;

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
     open-in-view: false
     generate-ddl: false
     hibernate:
-      ddl-auto: none
+      ddl-auto: create
       show-sql: true
       format-sql: true
   datasource:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -12,9 +12,8 @@ spring:
     open-in-view: false
     generate-ddl: false
     hibernate:
-      ddl-auto: create
-      show-sql: true
-      format-sql: true
+      ddl-auto: none
+    show-sql: true
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${DB_URL}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -79,5 +79,19 @@ springdoc:
   api-docs:
     groups:
       enabled: true
+cloud:
+  aws:
+    credentials:
+      access-key: ${S3_ACCESS_KEY}
+      secret-key: ${S3_SECRET_ACCESS_KEY}
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+
+application:
+  bucket:
+    name: ${BUCKET_NAME}
+
 
 


### PR DESCRIPTION
### 작업 사항

### 회원/비회원 구분 로직 작성
> #### @JwtTokenValidation
> 회원 여부 확인하는 annotation. 비회원도 이용 가능한 엔드포인트의 경우 포함되지 않음
> 1차로 CustomJwtFilter에서 확인(accessToken, refreshToken 둘 다 비어 있을 경우 그대로 넘어감)
> 컨트롤러에 해당 어노테이션이 있을 경우, accessToken과 refreshToken에 관한 유효성을 검사
> Interceptor 구현체 : 
> <img width="1079" alt="스크린샷 2024-01-11 오후 5 54 25" src="https://github.com/Lost42/Lost42/assets/44596433/46d23867-8f47-4af2-9130-3eeffdc0e456">
> Authentication 객체를 만들지 않고, 단순히 accessToken과 refreshToken이 필요한 서비스에서 정상적으로 들어왔는지만 판단

### Board CRUD 구현

> #### 전체 게시글 조회(POST) : 검색 및 조건 기능과 페이징 기능이 포함되어 있기 때문에 Post 요청을 받게 됨
> <img width="918" alt="스크린샷 2024-01-11 오후 5 57 27" src="https://github.com/Lost42/Lost42/assets/44596433/3dce0bdd-d087-4da1-902a-c9ea6dddd3af">
> 구현체:
> <img width="1018" alt="스크린샷 2024-01-11 오후 5 58 18" src="https://github.com/Lost42/Lost42/assets/44596433/e7c7c75f-950f-4a05-8776-1ee785d01079">
> 숫자가 낮은 페이지일수록 최신 게시글을 가져오게 됨 (현재 설정: 1페이지 당 게시글 10개)
> 결과
> <img width="763" alt="스크린샷 2024-01-11 오후 5 59 39" src="https://github.com/Lost42/Lost42/assets/44596433/fd35a2c3-1cb0-44ca-bc10-ec2d7bae6282">
> 마지막에 현재 페이지와 검색 조건에 맞는 게시글의 전체 개수도 함께 반환
> <img width="724" alt="스크린샷 2024-01-11 오후 6 00 00" src="https://github.com/Lost42/Lost42/assets/44596433/234fe2a4-8de4-4028-9d05-2a89756d18a5">
> QueryDsl 사용. 구현체: BoardRepositoryImpl

> #### 상세 게시글 조회(GET) : 로그인 유저일 때의 결과와, 비로그인 유저일 때의 결과를 다르게 하기 위해(isWirter 여부) 컨트롤러 2개 별개로 사용
> <img width="1156" alt="스크린샷 2024-01-11 오후 6 01 54" src="https://github.com/Lost42/Lost42/assets/44596433/7bb08db1-0eda-4225-8835-0e67a79f10f3">
> 이미지가 있을 경우, "boardImage"칸에 이미지 주소 리턴. 없을 경우 null

> #### 게시글 작성(POST) : json데이터와 image데이터를 함께 받을 수 있음. 
> <img width="1146" alt="스크린샷 2024-01-11 오후 6 02 39" src="https://github.com/Lost42/Lost42/assets/44596433/31ed146b-178d-48bc-a20b-ea0d21743587">
> 요청 조건
> <img width="822" alt="스크린샷 2024-01-11 오후 6 03 30" src="https://github.com/Lost42/Lost42/assets/44596433/0b647732-851f-4a5c-95c5-b0c5d72f4488">
> json 데이터의 경우 data로 감싸여 작성 및 application/json 타입 요청, 이미지의 경우 이미지 파일과 multipart/form-data 타입 요청
> 성공 시 게시글 번호 리턴
> <img width="744" alt="스크린샷 2024-01-11 오후 6 04 55" src="https://github.com/Lost42/Lost42/assets/44596433/d2b28bfd-2391-424f-8839-fea6af22b6d0">
> 이미지파일의 경우 게시글제목+날짜의 방식으로 AWS S3에 저장됨. 현재는 1개의 이미지만 받을 수 있음
> <img width="778" alt="스크린샷 2024-01-11 오후 6 06 10" src="https://github.com/Lost42/Lost42/assets/44596433/ce9dcef9-43d5-4c3a-bdb0-dd2b92b2013c">

> #### 게시글 수정(PATCH)
><img width="1153" alt="스크린샷 2024-01-11 오후 6 07 40" src="https://github.com/Lost42/Lost42/assets/44596433/13cab44e-a27c-44f0-a378-6b7768de9522">
> 관리자이거나 게시글 작성자 본인일 경우 접근 가능. 이미지 수정은 현재 불가능

> #### 게시글 삭제(DELETE)
> <img width="971" alt="스크린샷 2024-01-11 오후 6 08 46" src="https://github.com/Lost42/Lost42/assets/44596433/9d32f6b0-3c5f-40b4-a802-9d29aaa6f6dc">
> 실제 DB상에서 삭제를 하지 않고 deleteDt 설정(Soft Delete)

> #### Enum 타입 설정
>> BoardStatus
>><img width="909" alt="스크린샷 2024-01-11 오후 6 11 26" src="https://github.com/Lost42/Lost42/assets/44596433/ba09c356-1c34-48c6-8faa-6cc246e66203"> 
>> BoardType
>><img width="906" alt="스크린샷 2024-01-11 오후 6 10 55" src="https://github.com/Lost42/Lost42/assets/44596433/eea7d9fe-f20c-4c4a-9ca9-ca67509fee03">
>> 추후 프론트와 타입 이름들에 대한 논의 필요
